### PR TITLE
[RFR] Make new signin screen option for all cas, all the time

### DIFF
--- a/website/static/css/pages/login-page.css
+++ b/website/static/css/pages/login-page.css
@@ -1,3 +1,7 @@
+#signInContainer {
+    height: 600px;
+}
+
 .toggle-box {
     height: 320px;
     border: 1px solid #EEE;
@@ -37,4 +41,13 @@
 .toggle-box-muted .btn-success {
     background-color: #CCC;
     border-color: #BBB;
+}
+.existing-user-signin {
+    background-color: #EEE;
+    border-radius: 4px;
+}
+
+#termsAndConditions {
+    margin-top: 25px;
+    margin-bottom: 100px;
 }

--- a/website/static/css/pages/login-page.css
+++ b/website/static/css/pages/login-page.css
@@ -43,7 +43,7 @@
     border-color: #BBB;
 }
 .existing-user-signin {
-    background-color: #EEE;
+    background: #f7f7f7;
     border-radius: 4px;
 }
 

--- a/website/templates/public/login.mako
+++ b/website/templates/public/login.mako
@@ -52,11 +52,8 @@
     </div>
     %endif
     %if campaign != "institution" or not enable_institutions:
-        %if sign_up:
-            <div class="col-sm-5 col-sm-offset-1 toggle-box toggle-box-left toggle-box-muted p-h-lg">
-        %else:
+        %if not sign_up:
             <div class="col-sm-5 col-sm-offset-1 toggle-box toggle-box-left toggle-box-active p-h-lg">
-        %endif
         <form
             id="logInForm"
             class="form-horizontal"
@@ -106,8 +103,13 @@
             </div>
         </form>
     </div>
+        %else:
+            <div id="logInForm"></div>
+            <div id="signUpScope"></div>
+        %endif
+
         %if sign_up:
-            <div id="signUpScope" class="col-sm-5 toggle-box toggle-box-right toggle-box-active p-h-lg" style="height: auto;">
+            <div class="col-sm-6 col-sm-offset-3 existing-user-signin p-b-md m-b-m">
         %else:
             <div id="signUpScope" class="col-sm-5 toggle-box toggle-box-right toggle-box-muted p-h-lg" style="height: auto;">
         %endif
@@ -217,6 +219,25 @@
             <div class="help-block" >
                 <p data-bind="html: flashMessage, attr: {class: flashMessageClass}"></p>
             </div>
+            %if sign_up:
+                    </br>
+            <div class="form-group">
+                <div class="col-sm-4">
+                    <a href="#" >Already have an account?</a>
+                </div>
+                <div class="col-sm-8">
+                    <button type="submit" class="btn pull-right btn-success" data-bind="disable: submitted()">Create account</button>
+                </div>
+            </div>
+
+        </form>
+    </div>
+
+    <div id="termsAndConditions" class="col-sm-6 col-sm-offset-3">
+        <p> By clicking "Create account", you agree to our <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md">Terms</a> and that you have read our <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>, including our information on <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md#f-cookies">Cookie Use</a>.</p>
+    </div>
+    </div>
+            %else:
             <div>
                 <p> By clicking "Create account", you agree to our <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md">Terms</a> and that you have read our <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>, including our information on <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md#f-cookies">Cookie Use</a>.</p>
             </div>
@@ -234,7 +255,7 @@
         %endif
     %endif
 </div>
-
+%endif
 </%def>
 
 <%def name="javascript_bottom()">

--- a/website/templates/public/login.mako
+++ b/website/templates/public/login.mako
@@ -105,7 +105,7 @@
     </div>
         %else:
             <div id="logInForm"></div>
-            <div id="signUpScope"></div>
+            <div id="signu"></div>
         %endif
 
         %if sign_up:
@@ -222,10 +222,10 @@
             %if sign_up:
                     </br>
             <div class="form-group">
-                <div class="col-sm-4">
-                    <a href="#" >Already have an account?</a>
+                <div class="col-sm-6">
+                    <a class="m-l-md" href="#" >Already have an account?</a>
                 </div>
-                <div class="col-sm-8">
+                <div class="col-sm-6">
                     <button type="submit" class="btn pull-right btn-success" data-bind="disable: submitted()">Create account</button>
                 </div>
             </div>

--- a/website/templates/public/login.mako
+++ b/website/templates/public/login.mako
@@ -109,7 +109,7 @@
         %endif
 
         %if sign_up:
-            <div class="col-sm-6 col-sm-offset-3 existing-user-signin p-b-md m-b-m">
+            <div id="signUpScope" class="col-sm-6 col-sm-offset-3 existing-user-signin p-b-md m-b-m">
         %else:
             <div id="signUpScope" class="col-sm-5 toggle-box toggle-box-right toggle-box-muted p-h-lg" style="height: auto;">
         %endif
@@ -217,13 +217,13 @@
             </div>
             <!-- Flashed Messages -->
             <div class="help-block" >
-                <p data-bind="html: flashMessage, attr: {class: flashMessageClass}"></p>
+                <p class="m-l-md" data-bind="html: flashMessage, attr: {class: flashMessageClass}"></p>
             </div>
             %if sign_up:
                     </br>
             <div class="form-group">
                 <div class="col-sm-6">
-                    <a class="m-l-md" href="#" >Already have an account?</a>
+                    <a class="m-l-md" href="${login_url}" >Already have an account?</a>
                 </div>
                 <div class="col-sm-6">
                     <button type="submit" class="btn pull-right btn-success" data-bind="disable: submitted()">Create account</button>


### PR DESCRIPTION
## Purpose

To create a new sign in screen now that logging in from the osf is a no no.  
## Changes
## Before

<img width="1157" alt="screen shot 2016-06-02 at 2 52 16 pm" src="https://cloud.githubusercontent.com/assets/6232068/15757014/b2b13ce6-28d1-11e6-9ee0-4a0acb42e6b4.png">
## After

<img width="1177" alt="screen shot 2016-06-02 at 2 52 32 pm" src="https://cloud.githubusercontent.com/assets/6232068/15757016/b492f57c-28d1-11e6-999d-929b02dce995.png">
## Ticket

https://openscience.atlassian.net/browse/OSF-6438
https://openscience.atlassian.net/browse/SEC-26
